### PR TITLE
Add step to README to adjust proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ dependency download faster when building Rust project.
    source env/bin/activate
    pip install -r requirements.txt
    ```
-3. Run this program: `python app.py`
-4. (Optional)Serve a mirror site:
+3. Adjust the proxies defined at the top of app.py to match your network setup
+   (if you don't connect through a proxy, remove the proxies defined here)
+4. Run this program: `python app.py`
+5. (Optional)Serve a mirror site:
    ```
    cd crates
    python -m http.server 8000


### PR DESCRIPTION
The proxies defined in app.py should be mentioned in the README for anyone who doesn't have a proxy setup. Alternatively, you could just leave that array blank by default, but comment out examples that show how to use it.